### PR TITLE
this commit fixes UnicodeEncodeError when authenticating as google user with non ascii name

### DIFF
--- a/tipfy/auth/openid.py
+++ b/tipfy/auth/openid.py
@@ -78,7 +78,7 @@ class OpenIdMixin(object):
 
         # Verify the OpenID response via direct request to the OP
         url = openid_endpoint or self._OPENID_ENDPOINT
-        args = dict((k, v[-1]) for k, v in self.request.args.lists())
+        args = dict((k, v[-1].encode('utf8')) for k, v in self.request.args.lists())
         args['openid.mode'] = u'check_authentication'
 
         try:


### PR DESCRIPTION
without fix i get error:

File "/base/data/home/apps/s~okcloud/1.350529966893286596/lib/tipfy/auth/google.py", line 122, in get_authenticated_user
return OpenIdMixin.get_authenticated_user(self, callback)
File "/base/data/home/apps/s~okcloud/1.350529966893286596/lib/tipfy/auth/openid.py", line 86, in get_authenticated_user
payload=urllib.urlencode(args))
File "/base/python_runtime/python_dist/lib/python2.5/urllib.py", line 1259, in urlencode
v = quote_plus(str(v))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)
